### PR TITLE
disabled accessing self.kind for newer Puppet versions

### DIFF
--- a/lib/puppet/reports/elk_report.rb
+++ b/lib/puppet/reports/elk_report.rb
@@ -98,6 +98,12 @@ Puppet::Reports.register_report(:elk_report) do
         logs << log
       end
 
+      if Puppet.version <= '5.0.0'
+        body_type = self.kind
+      else
+        body_type = 'unavailable'
+      end
+
       client.create index: "puppet-#{Time.now.utc.to_date}",
         type: 'log',
         body: {
@@ -108,7 +114,7 @@ Puppet::Reports.register_report(:elk_report) do
          status: global_status,
          host: self.host,
          time: self.time,
-         type: self.kind,
+         type: body_type,
          tags: ['puppet', 'puppet_log'],
          published: true,
          published_at: Time.now.utc.iso8601,


### PR DESCRIPTION
when posting a report to ES an error was logged in the puppetserver.log:
```
2018-04-15 18:17:26,775 ERROR [qtp263002892-564] [puppetserver] Puppet undefined method `kind' for #<Puppet::Transaction::Report:0x39585833>
```

After removing access to self.kind the error disappeared. The body type field in ES is filled to 'unavailable' - this may need to be solved more elegantly.